### PR TITLE
Fixes for Issue #23, #28

### DIFF
--- a/captionsProcessor.ipynb
+++ b/captionsProcessor.ipynb
@@ -45,7 +45,7 @@
    "source": [
     "from topicExtractor import retrieveTopics\n",
     "\n",
-    "topicModeller = retrieveTopics(config, videoData) #, overwrite=True)\n",
+    "topicModeller = retrieveTopics(config) #, videoData) #, overwrite=True)\n",
     "topicModeller.printTopics()"
    ]
   },
@@ -57,7 +57,7 @@
    "source": [
     "from questionGenerator import retrieveQuestions\n",
     "\n",
-    "questionData = retrieveQuestions(config, topicModeller, videoData) #, overwrite=True)\n",
+    "questionData = retrieveQuestions(config) #, topicModeller, videoData) #, overwrite=True)\n",
     "questionData.printQuestions()"
    ]
   },

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -34,12 +34,6 @@ OVERWRITE_EXISTING_TOPICMODEL = 0
 # Defaults to 0
 OVERWRITE_EXISTING_QUESTIONS = 0
 
-# Minimum threshold for the video duration in seconds for processing.
-# Shorter videos might not have enough content to generate meaningful topics and questions.
-# Value must be >= 300s, but it is recommended to have it over 600s.
-# Defaults to 300.
-MINIMUM_VIDEO_DURATION = 300
-
 # Approximate window size of the captions taken from the .srt file.
 # Value must be >= 1, but it is recommended to keep it between 10-30.
 # Defaults to 30.

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -34,6 +34,12 @@ OVERWRITE_EXISTING_TOPICMODEL = 0
 # Defaults to 0
 OVERWRITE_EXISTING_QUESTIONS = 0
 
+# Minimum threshold for the video duration in seconds for processing.
+# Shorter videos might not have enough content to generate meaningful topics and questions.
+# Value must be >= 300s, but it is recommended to have it over 600s.
+# Defaults to 300.
+MINIMUM_VIDEO_DURATION = 300
+
 # Approximate window size of the captions taken from the .srt file.
 # Value must be >= 1, but it is recommended to keep it between 10-30.
 # Defaults to 30.

--- a/configData.py
+++ b/configData.py
@@ -32,7 +32,7 @@ for folder in fileTypes:
             os.makedirs(folderPath)
     except OSError:
         logging.error(f"Creation of the directory {folderPath} failed.")
-        sys.exit(f"Creation of the directory {folderPath} failed. Exiting..")
+        sys.exit(f"Directory creation failure. Exiting...")
 
 
 class configVars:
@@ -120,9 +120,8 @@ class configVars:
         """
 
         if not os.path.exists(".env"):
-            errorMsg = "No .env file found. Please configure your environment variables use the .env.sample file as a template."
-            logging.error(errorMsg)
-            sys.exit(errorMsg)
+            logging.error("No .env file found. Please configure your environment variables use the .env.sample file as a template.")
+            sys.exit("Missing .env file. Exiting...")
 
         # Force the environment variables to be read from the .env file every time.
         load_dotenv(".env", override=True)
@@ -237,7 +236,7 @@ class configVars:
         )
 
         if False in envImportSuccess.values():
-            sys.exit("Exiting due to configuration parameter import problems.")
+            sys.exit("Configuration parameter import problems. Exiting...")
 
         # This checks to set data in the later stages to be overwritten if the earlier stages are set to be overwritten.
         if self.overwriteTranscriptData == True:
@@ -325,7 +324,7 @@ class OpenAIBot:
 
             except openai.AuthenticationError as e:
                 logging.error(f"Error Message: {e}")
-                sys.exit("Exiting due to invalid OpenAI credentials.")
+                sys.exit("Invalid OpenAI credentials. Exiting...")
             except openai.RateLimitError as e:
                 logging.error(f"Error Message: {e}")
                 logging.error("Rate limit hit. Pausing for a minute.")
@@ -346,7 +345,7 @@ class OpenAIBot:
             logging.error(
                 f"Failed to send message at max limit of {self.callMaxLimit} times."
             )
-            sys.exit("Exiting due to too many failed attempts.")
+            sys.exit("Too many failed attempts. Exiting...")
 
         elif callComplete:
             responseText = response.choices[0].message.content

--- a/configData.py
+++ b/configData.py
@@ -10,9 +10,9 @@ from langchain.chains.question_answering import load_qa_chain
 from langchain_openai import AzureChatOpenAI as langchainAzureOpenAI
 
 logging.basicConfig(
-    format='%(asctime)s %(levelname)-4s [%(filename)s:%(lineno)d] - %(message)s',
-    datefmt='%Y-%m-%dT%H:%M:%S%z',
-    level=logging.INFO
+    format="%(asctime)s %(levelname)-4s [%(filename)s:%(lineno)d] - %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S%z",
+    level=logging.INFO,
 )
 
 captionsFolder: str = "Captions"
@@ -43,6 +43,8 @@ class configVars:
         }
 
         self.videoToUse: str = ""
+
+        self.minVideoLength: int = 300
         self.windowSize: int = 30
 
         self.overwriteTranscriptData: bool = False
@@ -160,6 +162,16 @@ class configVars:
                 lambda name: len(name) > 0,
             )
             envImportSuccess[self.videoToUse] = False if not self.videoToUse else True
+
+        self.minVideoLength = self.configFetch(
+            "MINIMUM_VIDEO_DURATION",
+            self.minVideoLength,
+            int,
+            lambda x: x >= 300,
+        )
+        envImportSuccess[self.minVideoLength] = (
+            False if not self.minVideoLength else True
+        )
 
         self.windowSize = self.configFetch(
             "WINDOW_SIZE",

--- a/configData.py
+++ b/configData.py
@@ -20,6 +20,11 @@ saveFolder: str = "savedData"
 fileTypes = ["transcriptData", "topicModel", "topicsOverTime", "questionData"]
 representationModelType: str = "langchain"
 
+# Minimum threshold for the video duration in seconds for processing.
+# Shorter videos might not have enough content to generate meaningful topics and questions.
+# Default is 300s.
+minVideoLength: int = 300
+
 for folder in fileTypes:
     folderPath = os.path.join(saveFolder, folder)
     try:
@@ -44,7 +49,6 @@ class configVars:
 
         self.videoToUse: str = ""
 
-        self.minVideoLength: int = 300
         self.windowSize: int = 30
 
         self.overwriteTranscriptData: bool = False
@@ -162,16 +166,6 @@ class configVars:
                 lambda name: len(name) > 0,
             )
             envImportSuccess[self.videoToUse] = False if not self.videoToUse else True
-
-        self.minVideoLength = self.configFetch(
-            "MINIMUM_VIDEO_DURATION",
-            self.minVideoLength,
-            int,
-            lambda x: x >= 300,
-        )
-        envImportSuccess[self.minVideoLength] = (
-            False if not self.minVideoLength else True
-        )
 
         self.windowSize = self.configFetch(
             "WINDOW_SIZE",

--- a/configData.py
+++ b/configData.py
@@ -124,7 +124,8 @@ class configVars:
             logging.error(errorMsg)
             sys.exit(errorMsg)
 
-        load_dotenv()
+        # Force the environment variables to be read from the .env file every time.
+        load_dotenv(".env", override=True)
 
         try:
             self.logLevel = str(os.environ.get("LOG_LEVEL", self.logLevel)).upper()

--- a/questionGenerator.py
+++ b/questionGenerator.py
@@ -5,6 +5,7 @@ import pandas as pd
 from utils import dataLoader, dataSaver
 from configData import OpenAIBot
 
+
 class QuestionData:
     """
     Represents a class for managing question data.
@@ -40,7 +41,6 @@ class QuestionData:
         """
         self.config = config
         self.videoData = None
-        self.topicModeller = None
 
         self.clusteredTopics = None
         self.dominantTopics = None
@@ -187,7 +187,7 @@ class QuestionData:
 
 
 # Using a manual overwrite option for debugging.
-def retrieveQuestions(config, topicModeller, videoData=None, overwrite=False):
+def retrieveQuestions(config, topicModeller=None, videoData=None, overwrite=False):
     """
     Retrieves or generates question data based on the given configuration and topic modeller.
 
@@ -210,7 +210,7 @@ def retrieveQuestions(config, topicModeller, videoData=None, overwrite=False):
             logging.info("Question Data loaded from saved files.")
             logging.info(f"Question Data Count: {len(questionData.responseData)}")
             return questionData
-        
+
     if topicModeller is None:
         logging.error("Topic Modeller not provided. Exiting...")
         sys.exit("Topic Modeller not provided. Exiting...")

--- a/questionGenerator.py
+++ b/questionGenerator.py
@@ -212,7 +212,9 @@ def retrieveQuestions(config, topicModeller=None, videoData=None, overwrite=Fals
             return questionData
 
     if topicModeller is None:
-        logging.error("Topic Modeller not provided. Exiting...")
+        logging.error(
+            "No saved data was found, and Topic Modeller not provided in function call needed to generate Question Data."
+        )
         sys.exit("Topic Modeller not provided. Exiting...")
     else:
         questionData.initialize(topicModeller, videoData)
@@ -260,9 +262,11 @@ def getClusteredTopics(topicModeller, videoData=None):
         dominantTopic = group[1].iloc[0]["Topic"]
         if dominantTopic != -1:
             filteredGroups.append(group[1])
-            
+
     if len(filteredGroups) == 0:
-        logging.error("No relevant topics found. Exiting...")
+        logging.error(
+            "Relevant topics not found. This could happen if video is too short or BERTopic could not find any topics."
+        )
         sys.exit("No relevant topics found. Exiting...")
 
     filteredGroupsDF = pd.concat(filteredGroups)
@@ -312,7 +316,7 @@ def getClusteredTopics(topicModeller, videoData=None):
     except Exception as e:
         logging.error(f"Error clustering topics: {e}")
         logging.error(f"Clustering error on Video: {videoData.config.videoToUse}")
-        sys.exit(f"Error clustering topics: {e}")
+        sys.exit(f"Topic clustering error. Exiting...")
 
     # We add the topic title for clarity in the final DataFrame.
     clusteredTopics["Topic Title"] = clusteredTopics["Topic"].apply(
@@ -322,8 +326,10 @@ def getClusteredTopics(topicModeller, videoData=None):
     )
 
     if clusteredTopics.shape[0] == 0:
-        logging.info("No clustered topics found. Exiting...")
-        sys.exit("No clustered topics found. Exiting...")
+        logging.info(
+            "No clustered topics found. This error should be unlikely and caused by a bug."
+        )
+        sys.exit("Topic clustering error. Exiting...")
 
     logging.info(f"Clustered Topics data shape: {clusteredTopics.shape}")
     logging.info(f"Clustered Topics head: {clusteredTopics.head(5)}")
@@ -350,7 +356,9 @@ def getDominantTopic(clusteredTopics):
     dominantTopics = pd.concat(dominantTopics).sort_values("Start")
 
     if dominantTopics.shape[0] == 0:
-        logging.error("No dominant topics found. Exiting...")
+        logging.error(
+            "No dominant topics found. This error should be unlikely and caused by a bug."
+        )
         sys.exit("No dominant topics found. Exiting...")
 
     logging.info(f"Dominant Topics data shape: {dominantTopics.shape}")

--- a/questionGenerator.py
+++ b/questionGenerator.py
@@ -260,6 +260,10 @@ def getClusteredTopics(topicModeller, videoData=None):
         dominantTopic = group[1].iloc[0]["Topic"]
         if dominantTopic != -1:
             filteredGroups.append(group[1])
+            
+    if len(filteredGroups) == 0:
+        logging.error("No relevant topics found. Exiting...")
+        sys.exit("No relevant topics found. Exiting...")
 
     filteredGroupsDF = pd.concat(filteredGroups)
 

--- a/topicExtractor.py
+++ b/topicExtractor.py
@@ -214,7 +214,7 @@ class TopicModeller:
 
 
 # Using a manual overwrite option for debugging.
-def retrieveTopics(config, videoData, overwrite=False):
+def retrieveTopics(config, videoData=None, overwrite=False):
     """
     Retrieves topics using the specified configuration and video data.
 

--- a/topicExtractor.py
+++ b/topicExtractor.py
@@ -18,6 +18,7 @@ from numpy import seterr
 
 seterr(divide="ignore")
 
+
 class TopicModeller:
     """
     Class for performing topic modeling on video data.
@@ -181,8 +182,10 @@ class TopicModeller:
             fitSuccess = self.fitTopicModel()
 
         if not fitSuccess:
-            logging.error("Failed to fit the topic model. Exiting...")
-            sys.exit("Failed to fit the topic model. Exiting...")
+            logging.error(
+                "Failed to fit the topic model. PLease check logs for possible errors."
+            )
+            sys.exit("FTopic model fitting failed. Exiting...")
 
         if representationModelType == "langchain":
             self.tokenCount = cb.total_tokens
@@ -244,7 +247,9 @@ def retrieveTopics(config, videoData=None, overwrite=False):
     logging.info("Generating & saving Topic Model and Data...")
 
     if videoData is None:
-        logging.error("Video Data not provided. Exiting...")
+        logging.error(
+            "No saved data was found, and no video data was provided in function call needed to extract topics."
+        )
         sys.exit("Video Data not provided. Exiting...")
     else:
         topicModeller.intialize(videoData)

--- a/topicExtractor.py
+++ b/topicExtractor.py
@@ -228,7 +228,7 @@ def retrieveTopics(config, videoData, overwrite=False):
     Returns:
         TopicModeller: The topic modeller object containing the generated topics and data.
     """
-    topicModeller = TopicModeller(config, videoData)
+    topicModeller = TopicModeller(config)
     if not config.overwriteTopicModel and not overwrite:
         topicModeller.makeTopicModel(load=True)
         if (
@@ -243,6 +243,11 @@ def retrieveTopics(config, videoData, overwrite=False):
 
     logging.info("Generating & saving Topic Model and Data...")
 
+    if videoData is None:
+        logging.error("Video Data not provided. Exiting...")
+        sys.exit("Video Data not provided. Exiting...")
+    else:
+        topicModeller.intialize(videoData)
     topicModeller.makeTopicModel(load=False)
     topicModeller.saveTopicModel()
 

--- a/transcriptLoader.py
+++ b/transcriptLoader.py
@@ -46,7 +46,7 @@ class TranscriptData:
             self.loadTranscriptData()
         else:
             self.srtFiles = self.validateVideoFiles()
-            self.transcript = processSrtFiles(self.srtFiles)
+            self.transcript = processSrtFiles(self.srtFiles, self.config.minVideoLength)
             self.combinedTranscript = getCombinedTranscripts(
                 self.transcript, self.config.windowSize
             )
@@ -127,7 +127,7 @@ class TranscriptData:
         )
 
 
-def processSrtFiles(srtFiles):
+def processSrtFiles(srtFiles, minTranscriptLength=300):
     """
     Process SRT files and extract transcript data.
 
@@ -179,6 +179,16 @@ def processSrtFiles(srtFiles):
     if transcriptDF.shape[0] == 0:
         logging.error(f"No transcript data found in {srtFiles[0]}. Exiting...")
         sys.exit("No transcript data found. Exiting...")
+        
+    if (transcriptDF["End"].iloc[-1] - transcriptDF["Start"].iloc[0]) < pd.Timedelta(
+        seconds=minTranscriptLength
+    ):
+        logging.error(
+            f"Video transcript is less than {minTranscriptLength} seconds long and not suitable for processing. Exiting..."
+        )
+        sys.exit(
+            f"Video transcript is less than {minTranscriptLength} seconds long and not suitable for processing. Exiting..."
+        )
 
     logging.info(f"Transcript data extracted from {srtFiles[0]}")
     logging.info(f"Transcript data shape: {transcriptDF.shape}")

--- a/transcriptLoader.py
+++ b/transcriptLoader.py
@@ -96,13 +96,13 @@ class TranscriptData:
             logging.error(
                 f"Captions folder not found. Created folder: {captionsFolder}."
             )
-            sys.exit("Captions folder not found. Exiting...")
+            sys.exit("Missing Captions parent folder. Exiting...")
 
         if not os.path.exists(os.path.join(captionsFolder, self.config.videoToUse)):
             logging.error(
                 f"Video folder not found for {self.config.videoToUse} in Caption folder {captionsFolder}."
             )
-            sys.exit("Captions folder not found. Exiting...")
+            sys.exit("Missing Video folder. Exiting...")
 
         srtFiles = glob.glob(
             os.path.join(captionsFolder, self.config.videoToUse, "*.srt")
@@ -186,9 +186,7 @@ def processSrtFiles(srtFiles, minTranscriptLength=minVideoLength):
         logging.error(
             f"Video transcript is less than {minTranscriptLength} seconds long and not suitable for processing. Exiting..."
         )
-        sys.exit(
-            f"Video transcript is less than {minTranscriptLength} seconds long and not suitable for processing. Exiting..."
-        )
+        sys.exit(f"Transcript too short. Exiting...")
 
     logging.info(f"Transcript data extracted from {srtFiles[0]}")
     logging.info(f"Transcript data shape: {transcriptDF.shape}")

--- a/transcriptLoader.py
+++ b/transcriptLoader.py
@@ -4,7 +4,7 @@ import sys
 import logging
 import pandas as pd
 from datetime import datetime
-from configData import captionsFolder
+from configData import captionsFolder, minVideoLength
 from utils import dataLoader, dataSaver
 
 
@@ -46,7 +46,7 @@ class TranscriptData:
             self.loadTranscriptData()
         else:
             self.srtFiles = self.validateVideoFiles()
-            self.transcript = processSrtFiles(self.srtFiles, self.config.minVideoLength)
+            self.transcript = processSrtFiles(self.srtFiles)
             self.combinedTranscript = getCombinedTranscripts(
                 self.transcript, self.config.windowSize
             )
@@ -127,7 +127,7 @@ class TranscriptData:
         )
 
 
-def processSrtFiles(srtFiles, minTranscriptLength=300):
+def processSrtFiles(srtFiles, minTranscriptLength=minVideoLength):
     """
     Process SRT files and extract transcript data.
 
@@ -179,7 +179,7 @@ def processSrtFiles(srtFiles, minTranscriptLength=300):
     if transcriptDF.shape[0] == 0:
         logging.error(f"No transcript data found in {srtFiles[0]}. Exiting...")
         sys.exit("No transcript data found. Exiting...")
-        
+
     if (transcriptDF["End"].iloc[-1] - transcriptDF["Start"].iloc[0]) < pd.Timedelta(
         seconds=minTranscriptLength
     ):


### PR DESCRIPTION
This should hopefully be a short PR. This fixes #23.

Two main things are fixed:
Data was not being loaded correctly for the `QuestionData` class in some cases. It saves more data that is useful in relation to the generated questions. This also adds a check while loading data similar to that of the `TranscriptData` class, where if the saved data doesn't match the expected format, it will regenerate the data. This reduces the chance that incorrect or older data will cause the script to stop running altogether, and instead attempt to reprocess it. 

The second issue is not one that is expected to come up often but has been implemented for consistency across all retrieval function calls. Simply put, if there is question data already generated for a given video, it does not make sense to also need to create the `TranscriptData` and `TopicModeller` objects for it, and try to directly load in the `QuestionData` itself.  
An example of this can be seen in the `captionsProcessor.ipynb` notebook, where all data if saved can be loaded directly using just the `configData` class. 

This functionality could be integrated with checks for saved data before running the whole script if needed as well in the future. 
