### PR TITLE
Addresses Issue #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@ This is the Github Project to Annoto GAI work.
 
 ## Initial setup: 
 1. Install required additonal libraries using `requirements.txt`.  
-2. Alongside installing the spaCy NLP library, you will need to download SpaCy's NLP model by running this command: `python -m spacy download en_core_web_sm`
-3. Use the `.env.sample` file in the `config` folder to create an `.env.` file to use with the needed credentials to use UM's OpenAI API.  
-4. For each video, create a folder in the `Captions` Folder, containing the corresponding .srt file within it. The first .srt file found in the subfolder will be used.  
+2. Use the `.env.sample` file in the `config` folder to create an `.env.` file to use with the needed credentials to use UM's OpenAI API.  
+3. For each video, create a folder in the `Captions` Folder, containing the corresponding .srt file within it. The first .srt file found in the subfolder will be used.  
 
 You can access videos from [MiVideo](https://www.mivideo.it.umich.edu/). It is recommended to use a video that is over 15 minutes long, and it must have .srt filetype captions available for it. Being familiar with the video contents can help in determining the utility and correctness of the topics extracted.
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ This is the Github Project to Annoto GAI work.
 
 ## Initial setup: 
 1. Install required additonal libraries using `requirements.txt`.  
-2. Use the `.env.sample` file in the `config` folder to create an `.env.` file to use with the needed credentials to use UM's OpenAI API.  
-3. For each video, create a folder in the `Captions` Folder, containing the corresponding .srt file within it. The first .srt file found in the subfolder will be used.  
+2. Alongside installing the spaCy NLP library, you will need to download SpaCy's NLP model by running this command: `python -m spacy download en_core_web_sm`
+3. Use the `.env.sample` file in the `config` folder to create an `.env.` file to use with the needed credentials to use UM's OpenAI API.  
+4. For each video, create a folder in the `Captions` Folder, containing the corresponding .srt file within it. The first .srt file found in the subfolder will be used.  
 
 You can access videos from [MiVideo](https://www.mivideo.it.umich.edu/). It is recommended to use a video that is over 15 minutes long, and it must have .srt filetype captions available for it. Being familiar with the video contents can help in determining the utility and correctness of the topics extracted.
 

--- a/captionsProcessor.ipynb
+++ b/captionsProcessor.ipynb
@@ -23,7 +23,7 @@
     "# ]\n",
     "\n",
     "config = configVars()\n",
-    "config.videoToUse = \"New Google Assignments in Canvas\"\n",
+    "config.videoToUse = \"IMSE 514 Presentation\"\n",
     "config.setFromEnv()"
    ]
   },
@@ -62,13 +62,6 @@
     "questionData = retrieveQuestions(config, topicModeller, videoData, overwrite=True)\n",
     "# questionData.printQuestions()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",

--- a/captionsProcessor.ipynb
+++ b/captionsProcessor.ipynb
@@ -14,14 +14,16 @@
     "\n",
     "# videoNames = [\n",
     "#     \"New Quizzes Video\",\n",
-    "#     \"Rearrange Playlist video\",\n",
-    "#     \"IMSE 514 Presentation\",\n",
     "#     \"New Google Assignments in Canvas\",\n",
     "#     \"Piazza Introduction Workshop\",\n",
+    "#     \"New Quizzes - Basics\", # This transcript does not yield usable topics as of now.\n",
+    "#     \"Sakai\", # This transcript does not yield usable topics as of now.\n",
+    "#     \"Rearrange Playlist video\", # This transcript is too short for topic generation.\n",
+    "#     \"IMSE 514 Presentation\", # This transcript was retrieved from YouTube with atuomatic captions, and fails at sentence segmentation.\n",
     "# ]\n",
     "\n",
     "config = configVars()\n",
-    "config.videoToUse = \"IMSE 514 Presentation\"\n",
+    "config.videoToUse = \"New Google Assignments in Canvas\"\n",
     "config.setFromEnv()"
    ]
   },
@@ -33,8 +35,8 @@
    "source": [
     "from transcriptLoader import retrieveTranscript\n",
     "\n",
-    "videoData = retrieveTranscript(config) #, overwrite=True)\n",
-    "videoData.printTranscript()"
+    "videoData = retrieveTranscript(config, overwrite=True)\n",
+    "# videoData.printTranscript()"
    ]
   },
   {
@@ -45,7 +47,7 @@
    "source": [
     "from topicExtractor import retrieveTopics\n",
     "\n",
-    "topicModeller = retrieveTopics(config) #, videoData) #, overwrite=True)\n",
+    "topicModeller = retrieveTopics(config, videoData, overwrite=True)\n",
     "topicModeller.printTopics()"
    ]
   },
@@ -57,9 +59,16 @@
    "source": [
     "from questionGenerator import retrieveQuestions\n",
     "\n",
-    "questionData = retrieveQuestions(config) #, topicModeller, videoData) #, overwrite=True)\n",
-    "questionData.printQuestions()"
+    "questionData = retrieveQuestions(config, topicModeller, videoData, overwrite=True)\n",
+    "# questionData.printQuestions()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/configData.py
+++ b/configData.py
@@ -25,6 +25,13 @@ representationModelType: str = "langchain"
 # Default is 300s.
 minVideoLength: int = 300
 
+# Because of how BERTopic works, there needs to be a minimum number of sentences per window of time.
+# When attempting to automatically segment the transcript into sentences using spaCy,
+# If there are sentences longer than this duration, the transcript data might not be suitable for this process.
+# Instead, the transcript will be segmented based on the `WINDOW_SIZE`.
+# Defaults to 120s, must be >=60.
+maxSentenceDuration = 120
+
 for folder in fileTypes:
     folderPath = os.path.join(saveFolder, folder)
     try:
@@ -120,7 +127,9 @@ class configVars:
         """
 
         if not os.path.exists(".env"):
-            logging.error("No .env file found. Please configure your environment variables use the .env.sample file as a template.")
+            logging.error(
+                "No .env file found. Please configure your environment variables use the .env.sample file as a template."
+            )
             sys.exit("Missing .env file. Exiting...")
 
         # Force the environment variables to be read from the .env file every time.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ pandas==2.2.2
 python-dotenv==1.0.1
 scikit_learn==1.4.2
 tiktoken
-spaCy==3.7
+spaCy==3.7.4
+https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,9 @@ pandas==2.2.2
 python-dotenv==1.0.1
 scikit_learn==1.4.2
 tiktoken
-spaCy==3.7.4
+spacy==3.7.4
+# spaCy has two components, the library itself, and the trained language model. 
+# The language model needs to be installed separately, and needs the download link to be specified. 
+# This is because there are numerous language models which can be used, and the user needs to specify which one they want to use.
+# Documentation: https://spacy.io/usage/models
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pandas==2.2.2
 python-dotenv==1.0.1
 scikit_learn==1.4.2
 tiktoken
+spaCy==3.7

--- a/transcriptLoader.py
+++ b/transcriptLoader.py
@@ -4,8 +4,9 @@ import sys
 import logging
 import pandas as pd
 from datetime import datetime
-from configData import captionsFolder, minVideoLength
+from configData import captionsFolder, minVideoLength, maxSentenceDuration
 from utils import dataLoader, dataSaver
+import spacy
 
 
 class TranscriptData:
@@ -24,6 +25,7 @@ class TranscriptData:
         self.config = config
         self.srtFiles = None
         self.transcript = None
+        self.processedSentences = None
         self.combinedTranscript = None
 
     def initialize(self, config):
@@ -47,9 +49,17 @@ class TranscriptData:
         else:
             self.srtFiles = self.validateVideoFiles()
             self.transcript = processSrtFiles(self.srtFiles)
-            self.combinedTranscript = getCombinedTranscripts(
-                self.transcript, self.config.windowSize
-            )
+            self.processedSentences = getSentences(self.transcript)
+            
+            if self.processedSentences is not None:
+                self.combinedTranscript = getCombinedTranscripts(
+                    self.processedSentences, self.config.windowSize
+                )
+            else:
+                # Revert to simple segmentation
+                self.combinedTranscript = getCombinedTranscripts(
+                    self.transcript, self.config.windowSize
+                )
             self.saveTranscriptData()
 
     def loadTranscriptData(self):
@@ -58,15 +68,16 @@ class TranscriptData:
         """
         loadedData = dataLoader(self.config, "transcriptData")
         if loadedData is None:
-            loadedData = [None] * 3
-        elif type(loadedData) != tuple or len(loadedData) != 3:
+            loadedData = [None] * 4
+        elif type(loadedData) != tuple or len(loadedData) != 4:
             logging.warning(
                 "Loaded data for Transcript Data is incomplete/broken. Data will be regenerated and saved."
             )
-            loadedData = [None] * 3
+            loadedData = [None] * 4
         (
             self.srtFiles,
             self.transcript,
+            self.processedSentences,
             self.combinedTranscript,
         ) = loadedData
 
@@ -78,6 +89,7 @@ class TranscriptData:
             (
                 self.srtFiles,
                 self.transcript,
+                self.processedSentences,
                 self.combinedTranscript,
             ),
             self.config,
@@ -123,7 +135,7 @@ class TranscriptData:
             f"Processed transcript data shape: {self.combinedTranscript.shape}"
         )
         logging.info(
-            f"Processed transcript data head: {self.combinedTranscript.head(5)}"
+            f"Processed transcript data head:\n {self.combinedTranscript.head(3)}"
         )
 
 
@@ -190,9 +202,86 @@ def processSrtFiles(srtFiles, minTranscriptLength=minVideoLength):
 
     logging.info(f"Transcript data extracted from {srtFiles[0]}")
     logging.info(f"Transcript data shape: {transcriptDF.shape}")
-    logging.info(f"Transcript data head: {transcriptDF.head(5)}")
+    logging.info(f"Transcript data head:\n {transcriptDF.head(3)}")
 
     return transcriptDF
+
+
+def getSentences(transcript):
+    """
+    Extracts sentences from a transcript using the spaCy library.
+    It contains a sentence boundary detection model that can attempt to parse and segment text into sentences.
+    https://spacy.io/usage/linguistic-features#sbd
+
+    Args:
+        transcript (DataFrame): A pandas DataFrame containing the transcript data.
+
+    Returns:
+        DataFrame: A pandas DataFrame containing the extracted sentences with their start and end positions.
+    """
+
+    # Download the spaCy model using the following command:
+    # python -m spacy download en_core_web_sm
+    nlp = spacy.load("en_core_web_sm")
+
+    parsedLines = nlp(" ".join(transcript["Line"].tolist()))
+
+    startIndex, endIndex = 0, 1
+    pastSentence = ""
+    sentences = []
+    for sentence in parsedLines.sents:
+        sentenceMatched = False
+        sentence = nlp(pastSentence + sentence.text)
+
+        while not sentenceMatched and endIndex <= len(transcript):
+            rows = transcript.iloc[startIndex:endIndex]
+
+            if len(sentence.text) < len(" ".join(rows["Line"])):
+                pastSentence = sentence.text + " "
+                sentenceMatched = True
+            elif sentence.text == " ".join(rows["Line"]):
+                sentenceMatched = True
+                sentences.append(
+                    {
+                        "Line": sentence.text,
+                        "Start": transcript.iloc[startIndex]["Start"],
+                        "End": transcript.iloc[endIndex - 1]["End"],
+                    }
+                )
+                startIndex = endIndex
+                pastSentence = ""
+            else:
+                endIndex += 1
+
+    processedSentences = pd.DataFrame(sentences)
+
+    if validateProcessedSentences(processedSentences, maxSentenceDuration):
+        logging.info(f"Sentences data shape: {processedSentences.shape}")
+        logging.info(f"Sentences data head:\n {processedSentences.head(3)}")
+
+        return processedSentences
+    else:
+        return None
+
+
+def validateProcessedSentences(
+    processedSentences, maxSentenceDuration=maxSentenceDuration
+):
+    if processedSentences.shape[0] == 0:
+        logging.warn(
+            f"No sentences found in the transcript data. Reverting to simple segmentation.",
+        )
+        return False
+
+    sentenceDurations = processedSentences["End"] - processedSentences["Start"]
+    if sentenceDurations.max().seconds > maxSentenceDuration:
+        logging.warn(
+            f"Maximum sentence duration exceeds {maxSentenceDuration} seconds, indicating possibly bad transcription data. Reverting to simple segmentation.",
+        )
+        return False
+
+    logging.info(f"Transcript successfully segmented into sentences.")
+    return True
 
 
 def getCombinedTranscripts(transcript, windowSize=30):
@@ -239,7 +328,7 @@ def getCombinedTranscripts(transcript, windowSize=30):
     logging.info(
         f"Combined Transcript data shape: {combinedTranscript.shape}",
     )
-    logging.info(f"Combined Transcript data head: {combinedTranscript.head(5)}")
+    logging.info(f"Combined Transcript data head:\n {combinedTranscript.head(3)}")
 
     return combinedTranscript
 
@@ -264,7 +353,7 @@ def retrieveTranscript(config, overwrite=False):
         if transcriptData.combinedTranscript is not None:
             logging.info("Transcript Data loaded from saved files.")
             logging.info(
-                f"Transcript Data Head: {transcriptData.combinedTranscript.head(5)}"
+                f"Transcript Data head:\n {transcriptData.combinedTranscript.head(3)}"
             )
             return transcriptData
 

--- a/transcriptLoader.py
+++ b/transcriptLoader.py
@@ -280,7 +280,7 @@ def validateProcessedSentences(
         )
         return False
 
-    logging.info(f"Transcript successfully segmented into sentences.")
+    logging.info(f"Transcript successfully segmented into sentences using spaCy.")
     return True
 
 

--- a/transcriptLoader.py
+++ b/transcriptLoader.py
@@ -219,9 +219,6 @@ def getSentences(transcript):
     Returns:
         DataFrame: A pandas DataFrame containing the extracted sentences with their start and end positions.
     """
-
-    # Download the spaCy model using the following command:
-    # python -m spacy download en_core_web_sm
     nlp = spacy.load("en_core_web_sm")
 
     parsedLines = nlp(" ".join(transcript["Line"].tolist()))


### PR DESCRIPTION
Adds code to segment transcript into sentences using the spaCy library to fix issue #1. The model used within spaCy can attempt to detect sentence boundaries in the transcript, and this is matched to the end of an SRT's caption. This helps that whole sentences are captured, so when a generated question is inserted at some point in a video, it will not interrupt a sentence midway. 

The script accounts for the possibility that sentence segmentation might fail which can occur when transcription quality is poor. This is determined by checking if any segmented sentence is over 2 minutes long. If this occurs, the script will fall back to a simpler segmentation process, where the SRT file is directly used to create 30s segments of text. This should allow for videos to be processed even when the transcription quality is not ideal. 