### PR TITLE
Fix for #29

### DIFF
--- a/captionsProcessor.ipynb
+++ b/captionsProcessor.ipynb
@@ -16,14 +16,14 @@
     "#     \"New Quizzes Video\",\n",
     "#     \"New Google Assignments in Canvas\",\n",
     "#     \"Piazza Introduction Workshop\",\n",
-    "#     \"New Quizzes - Basics\", # This transcript does not yield usable topics as of now.\n",
-    "#     \"Sakai\", # This transcript does not yield usable topics as of now.\n",
+    "#     \"New Quizzes - Basics\", # This transcript might fall back to K-Means in BERTopic for topic extraction.\n",
+    "#     \"Sakai\", # This transcript might fall back to K-Means in BERTopic for topic extraction.\n",
     "#     \"Rearrange Playlist video\", # This transcript is too short for topic generation.\n",
     "#     \"IMSE 514 Presentation\", # This transcript was retrieved from YouTube with atuomatic captions, and fails at sentence segmentation.\n",
     "# ]\n",
     "\n",
     "config = configVars()\n",
-    "config.videoToUse = \"IMSE 514 Presentation\"\n",
+    "config.videoToUse = \"New Quizzes - Basics\"\n",
     "config.setFromEnv()"
    ]
   },

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -39,11 +39,6 @@ OVERWRITE_EXISTING_QUESTIONS = 0
 # Defaults to 30.
 WINDOW_SIZE = 30
 
-# Toggle for using KeyBERT vectorization in the BERTopic Model. 
-# 0 for not using KeyBERT, 1 for using KeyBERT.
-# Defaults to 1.
-USE_KEY_BERT = 1
-
 # Specify the prompt for the LangChain model that runs atop the BERTopic model to generate a human-interpretable summary of the topics.
 # Defaults to the prompt below. Do not adjust this unless you tuning the outputs for the generated topics.
 LANGCHAIN_PROMPT = 'Give a single label that is only a few words long to summarize what these documents are about.'

--- a/configData.py
+++ b/configData.py
@@ -20,6 +20,9 @@ saveFolder: str = "savedData"
 fileTypes = ["transcriptData", "topicModel", "topicsOverTime", "questionData"]
 representationModelType: str = "langchain"
 
+# Toggle for using KeyBERT vectorization in the BERTopic Model. Default is True.
+useKeyBERT: bool = True
+
 # Minimum threshold for the video duration in seconds for processing.
 # Shorter videos might not have enough content to generate meaningful topics and questions.
 # Default is 300s.
@@ -212,16 +215,6 @@ class configVars:
         )
         envImportSuccess[self.overwriteQuestionData] = (
             False if type(self.overwriteQuestionData) is not bool else True
-        )
-
-        self.useKeyBERT = self.configFetch(
-            "USE_KEY_BERT",
-            self.useKeyBERT,
-            bool,
-            None,
-        )
-        envImportSuccess[self.useKeyBERT] = (
-            False if type(self.useKeyBERT) is not bool else True
         )
 
         self.langchainPrompt = self.configFetch(

--- a/topicExtractor.py
+++ b/topicExtractor.py
@@ -6,7 +6,7 @@ from langchain_community.callbacks import get_openai_callback
 import openai
 from bertopic import BERTopic
 from keybert import KeyBERT
-from configData import OpenAIBot, LangChainBot
+from configData import OpenAIBot, LangChainBot, useKeyBERT
 from utils import dataLoader, dataSaver, getBinCount
 from configData import representationModelType
 
@@ -60,7 +60,7 @@ class TopicModeller:
         else:
             vectorizerModel = (
                 getVectorizer(self.videoData.combinedTranscript)
-                if self.config.useKeyBERT
+                if useKeyBERT
                 else None
             )
             self.initializeRepresentationModel()

--- a/topicExtractor.py
+++ b/topicExtractor.py
@@ -146,12 +146,12 @@ class TopicModeller:
             try:
                 self.initializeTopicModel(vectorizerModel)
                 self.topics, probs = self.topicModel.fit_transform(docs)
+                logging.info(f"Topics and probalities extracted from fitted successfully.")
 
                 if set(self.topics) == {-1}:
                     logging.warning(
                         "All topics are -1. Retrying with K-means clustering..."
                     )
-
                     # This import should not occur frequently, so we only call when it is needed.
                     from sklearn.cluster import KMeans
 
@@ -171,6 +171,7 @@ class TopicModeller:
                     docs, timestamps, nr_bins=binCount
                 )
 
+                logging.info(f"Topics over time extracted successfully.")
                 return True
 
             except openai.AuthenticationError as e:

--- a/topicExtractor.py
+++ b/topicExtractor.py
@@ -6,7 +6,7 @@ from langchain_community.callbacks import get_openai_callback
 import openai
 from bertopic import BERTopic
 from keybert import KeyBERT
-from configData import OpenAIBot, LangChainBot, useKeyBERT
+from configData import OpenAIBot, LangChainBot, useKeyBERT, maxSentenceDuration
 from utils import dataLoader, dataSaver, getBinCount
 from configData import representationModelType
 
@@ -34,10 +34,12 @@ class TopicModeller:
         self.OpenAIChatBot = None
         self.LangChainQABot = None
         self.representationModel = None
-        self.topicModel = None
-        self.topicsOverTime = None
         self.tokenCount = 0
         self.callMaxLimit = 3
+
+        self.topicModel = None
+        self.topics = None
+        self.topicsOverTime = None
 
     def intialize(self, videoData):
         """
@@ -58,13 +60,7 @@ class TopicModeller:
         if load:
             self.loadTopicModel()
         else:
-            vectorizerModel = (
-                getVectorizer(self.videoData.combinedTranscript)
-                if useKeyBERT
-                else None
-            )
             self.initializeRepresentationModel()
-            self.initializeTopicModel(vectorizerModel)
             self.getTopicsOverTime()
 
     def loadTopicModel(self):
@@ -114,7 +110,7 @@ class TopicModeller:
                 self.LangChainQABot.chain, prompt=self.LangChainQABot.prompt
             )
 
-    def initializeTopicModel(self, vectorizerModel=None):
+    def initializeTopicModel(self, vectorizerModel=None, clusterModel=None):
         """
         Initialize the topic model.
 
@@ -126,6 +122,12 @@ class TopicModeller:
                 representation_model=self.representationModel,
                 vectorizer_model=vectorizerModel,
             )
+        if clusterModel is not None:
+            self.topicModel = BERTopic(
+                representation_model=self.representationModel,
+                vectorizer_model=vectorizerModel,
+                hdbscan_model=clusterModel,
+            )
         else:
             self.topicModel = BERTopic(representation_model=self.representationModel)
 
@@ -135,14 +137,34 @@ class TopicModeller:
         """
         docs = self.videoData.combinedTranscript["Combined Lines"].tolist()
         timestamps = self.videoData.combinedTranscript["Start"].tolist()
+        vectorizerModel = (
+            getVectorizer(self.videoData.combinedTranscript) if useKeyBERT else None
+        )
 
         callAttemptCount = 0
         while callAttemptCount < self.callMaxLimit:
             try:
-                topics, probs = self.topicModel.fit_transform(docs)
+                self.initializeTopicModel(vectorizerModel)
+                self.topics, probs = self.topicModel.fit_transform(docs)
 
+                if set(self.topics) == {-1}:
+                    logging.warning(
+                        "All topics are -1. Retrying with K-means clustering..."
+                    )
+
+                    # This import should not occur frequently, so we only call when it is needed.
+                    from sklearn.cluster import KMeans
+
+                    # We use 3 clusters as a default value. 
+                    # This means the transcript will be grouped into 3 topics.
+                    clusterModel = KMeans(n_clusters=3)
+                    self.initializeTopicModel(vectorizerModel, clusterModel)
+                    self.topics, probs = self.topicModel.fit_transform(docs)
+
+                # We use `maxSentenceDuration` to determine the number of bins.
+                # This ensures that bins will always have atleast one sentence in them.
                 binCount = getBinCount(
-                    self.videoData.combinedTranscript, windowSize=120
+                    self.videoData.combinedTranscript, windowSize=maxSentenceDuration
                 )
 
                 self.topicsOverTime = self.topicModel.topics_over_time(
@@ -257,7 +279,7 @@ def retrieveTopics(config, videoData=None, overwrite=False):
     topicModeller.saveTopicModel()
 
     logging.info(f"Topic Model and Data generated and saved for current configuration.")
-    logging.info(f"Topics over Time Head: {topicModeller.topicsOverTime.head(5)}")
+    logging.info(f"Topics over Time Head:\n {topicModeller.topicsOverTime.head(3)}")
     return topicModeller
 
 


### PR DESCRIPTION
Fix for #29.

Some videos have no clear topic consensus, where BERTopic will believe that a single topic is not discussed for long enough throughout the whole video. The reason for this will need to be understood through further testing and analysis of videos where this happens. Note that there is not a lack of topics at all, BERTopic still generates the subtopics that are being discussed over the course of the video but is unable to cluster them under a singular main topic. 

Switching the clustering model over to K_means instead of HBDScan ensures that a minimum number of topics are generated. Having the vectorizer model helps out as well, as it significantly cuts down on noise with the K_means algorithm.

K_means is inferior compared to HBDScan in most cases and is only used as a fallback option. It can often lead to two topics with the same title being generated. This can be fixed by appending a count to duplicate titles to indicate that they are different. However, a better solution might be to have a longer topic title generated using LangChain that is more descriptive. This can be implemented based on Q&A feedback on the generated question quality and utility.


Minor change to make `useKeyBERT` a constant value instead of a configurable value, as it should used by default, and is very useful especially for K-means clustering to assist in less noisy clustering.