### PR TITLE
Fixes #24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 
 Captions/
 savedData/
+Output Data/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ A basic saving and loading functionality is also utilized to load in the model a
 This is also why the `TopicModeller` class can't be saved as single entity easily. Saving the model in it needs a different mechanism. 
 In a future implementation, the need for the model being saved itself could be removed, but I do not believe this is viable right now.
 
+#### Understanding the generated question data:
+Question data is saved to a folder with the same name in an output folder called `Output Data` as the corresponding folder from the `Captions` folder whose transcript was used to generate the data from. The file is called `Questions.txt`, and for a given video will list the Video/Folder Name, the Topic, the timestamps for the selected relevant text, insertion time for the question, and then the questions itself. The question generated will be a multiple choice type, with 4 questions, one of which is the correct. A reasoning is also provided for this answer to be the correct one. 
+
 #### Scripts used:
 Currently, 5 scripts are used:
 1. `configData.py`: Contains the `configVars` class used to store environmental variables, as well as two other classes for OpenAI and LangChain API usage.

--- a/captionsProcessor.ipynb
+++ b/captionsProcessor.ipynb
@@ -35,7 +35,8 @@
    "source": [
     "from transcriptLoader import retrieveTranscript\n",
     "\n",
-    "videoData = retrieveTranscript(config, overwrite=True)\n",
+    "videoData = retrieveTranscript(config)\n",
+    "# videoData = retrieveTranscript(config, overwrite=True)\n",
     "# videoData.printTranscript()"
    ]
   },
@@ -47,7 +48,8 @@
    "source": [
     "from topicExtractor import retrieveTopics\n",
     "\n",
-    "topicModeller = retrieveTopics(config, videoData, overwrite=True)\n",
+    "topicModeller = retrieveTopics(config)\n",
+    "# topicModeller = retrieveTopics(config, videoData, overwrite=True)\n",
     "topicModeller.printTopics()"
    ]
   },
@@ -59,8 +61,10 @@
    "source": [
     "from questionGenerator import retrieveQuestions\n",
     "\n",
-    "questionData = retrieveQuestions(config, topicModeller, videoData, overwrite=True)\n",
-    "# questionData.printQuestions()"
+    "questionData = retrieveQuestions(config)\n",
+    "# questionData = retrieveQuestions(config, topicModeller, videoData, overwrite=True)\n",
+    "# questionData.printQuestions()\n",
+    "questionData.saveToFile()"
    ]
   },
   {

--- a/captionsProcessor.ipynb
+++ b/captionsProcessor.ipynb
@@ -10,8 +10,6 @@
     "%autoreload 2\n",
     "\n",
     "from configData import configVars\n",
-    "from transcriptLoader import TranscriptData\n",
-    "\n",
     "# videoNames = [\n",
     "#     \"New Quizzes Video\",\n",
     "#     \"New Google Assignments in Canvas\",\n",

--- a/captionsProcessor.py
+++ b/captionsProcessor.py
@@ -21,6 +21,7 @@ def main():
     logging.info(f"Retrieving Questions for {config.videoToUse}...")
     questionData = retrieveQuestions(config, topicModeller, videoData)
     questionData.printQuestions()
+    questionData.saveToFile()
 
 
 if __name__ == "__main__":

--- a/configData.py
+++ b/configData.py
@@ -18,6 +18,7 @@ logging.basicConfig(
 captionsFolder: str = "Captions"
 saveFolder: str = "savedData"
 fileTypes = ["transcriptData", "topicModel", "topicsOverTime", "questionData"]
+outputFolder: str = "Output Data"
 representationModelType: str = "langchain"
 
 # Toggle for using KeyBERT vectorization in the BERTopic Model. Default is True.

--- a/questionGenerator.py
+++ b/questionGenerator.py
@@ -196,6 +196,7 @@ class QuestionData:
         saveFolder = os.path.join(outputFolder, self.config.videoToUse)
         try:
             if not os.path.exists(saveFolder):
+                logging.info(f"Creating directory for Output: {saveFolder}")
                 os.makedirs(saveFolder)
         except OSError:
             logging.warn(
@@ -206,6 +207,7 @@ class QuestionData:
         questionSavePath = os.path.join(
             outputFolder, self.config.videoToUse, "Questions.txt"
         )
+        logging.info(f"Saving Question Data to file: {questionSavePath}")
         try:
             with open(questionSavePath, "w") as f:
                 f.write(f"Video Name / Parent Folder: {self.config.videoToUse}\n")
@@ -258,14 +260,11 @@ class QuestionData:
                         )
                         f.write(response)
             logging.info(f"Question Data saved to file: {questionSavePath}")
-            return True
         except OSError:
             logging.warn(f"Failed to save question data to file: {questionSavePath}")
-            return False
         except Exception as e:
             logging.warn(f"Failed to save question data to file: {questionSavePath}")
             logging.warn(f"Error: {e}")
-            return False
 
 # Using a manual overwrite option for debugging.
 def retrieveQuestions(config, topicModeller=None, videoData=None, overwrite=False):


### PR DESCRIPTION
This should be a small PR, but an important one for testing purposes. 

This fixes #24, and saves a human-readable text file for the generated questions. 
The implementation is very simple as of now, with ` questionData.saveToFile()` simply attempting to save the questions to a text file in the 'Output Data' folder.

Issue #25 has not been addressed in this PR as the code for this was already ready, and topic visualization needs some more nuance and code to have something that is intuitive and easily understandable by testers.