### PR TITLE
Fixes #27

### DIFF
--- a/captionsProcessor.ipynb
+++ b/captionsProcessor.ipynb
@@ -21,7 +21,7 @@
     "# ]\n",
     "\n",
     "config = configVars()\n",
-    "config.videoToUse = \"New Quizzes - Basics\"\n",
+    "config.videoToUse = \"New Google Assignments in Canvas\"\n",
     "config.setFromEnv()"
    ]
   },
@@ -48,7 +48,7 @@
     "\n",
     "topicModeller = retrieveTopics(config)\n",
     "# topicModeller = retrieveTopics(config, videoData, overwrite=True)\n",
-    "topicModeller.printTopics()"
+    "# topicModeller.printTopics()"
    ]
   },
   {

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -39,6 +39,13 @@ OVERWRITE_EXISTING_QUESTIONS = 0
 # Defaults to 30.
 WINDOW_SIZE = 30
 
+# If the duration of a given topic is longer than the context window, 
+# The text only from the end of the topic's duration matching the length of the context window 
+# Will be used for generating questions.
+# If set to 0, all of the data will be used.
+# Defaults to 600s for 10 minutes of context. Ideally should be a few minutes long at least for ebough relevent context.
+RELEVANT_TEXT_CONTEXT_WINDOW = 600
+
 # Specify the prompt for the LangChain model that runs atop the BERTopic model to generate a human-interpretable summary of the topics.
 # Defaults to the prompt below. Do not adjust this unless you tuning the outputs for the generated topics.
 LANGCHAIN_PROMPT = 'Give a single label that is only a few words long to summarize what these documents are about.'

--- a/configData.py
+++ b/configData.py
@@ -61,6 +61,7 @@ class configVars:
         self.videoToUse: str = ""
 
         self.windowSize: int = 30
+        self.contextWindowSize: int = 600
 
         self.overwriteTranscriptData: bool = False
         self.overwriteTopicModel: bool = False
@@ -187,6 +188,16 @@ class configVars:
             lambda x: x > 0,
         )
         envImportSuccess[self.windowSize] = False if not self.windowSize else True
+
+        self.contextWindowSize = self.configFetch(
+            "RELEVANT_TEXT_CONTEXT_WINDOW",
+            self.contextWindowSize,
+            int,
+            lambda x: x >= 0,
+        )
+        envImportSuccess[self.contextWindowSize] = (
+            False if self.contextWindowSize is None else True
+        )
 
         self.overwriteTranscriptData = self.configFetch(
             "OVERWRITE_EXISTING_TRANSCRIPT",

--- a/questionGenerator.py
+++ b/questionGenerator.py
@@ -67,9 +67,15 @@ class QuestionData:
 
         self.clusteredTopics = getClusteredTopics(topicModeller, videoData)
         self.dominantTopics = getDominantTopic(self.clusteredTopics)
+
+        # Check if the contextWindowSize is set to 0, which means we do not want to truncate the relevant text.
+        if self.config.contextWindowSize != 0:
+            # Truncate the relevant text as needed based on the contextWindowSize.
+            self.dominantTopics = truncateRelevantText(
+                self.dominantTopics, self.videoData, self.config.contextWindowSize
+            )
         self.relevantText, self.questionQueryText = getTextAndQuestion(
-            self.dominantTopics, videoData
-        )
+            self.dominantTopics, self.videoData)
 
     def makeQuestionData(self, load=True):
         """
@@ -219,7 +225,9 @@ class QuestionData:
 
                     startTime = self.dominantTopics[topic]["Start"]
                     endTime = self.dominantTopics[topic]["End"]
-                    durationMin, durationSec = divmod((endTime - startTime).total_seconds(), 60)
+                    durationMin, durationSec = divmod(
+                        (endTime - startTime).total_seconds(), 60
+                    )
 
                     f.write("\n---------------------------------------\n")
                     f.write(f"Topic: {topic}\n")
@@ -235,14 +243,11 @@ class QuestionData:
                     try:
                         parsedResponse = json.loads(response)
                         question = f"\nQuestion: {parsedResponse['question']}\n"
-                        answers = (
-                            "Answers: \n\t"
-                            + "\n\t".join(
-                                [
-                                    f"{i+1}. {item}"
-                                    for i, item in enumerate(parsedResponse["answers"])
-                                ]
-                            )
+                        answers = "Answers: \n\t" + "\n\t".join(
+                            [
+                                f"{i+1}. {item}"
+                                for i, item in enumerate(parsedResponse["answers"])
+                            ]
                         )
                         correct = f"Correct Answer: \n\t{parsedResponse['answers'].index(parsedResponse['correct'])+1}. {parsedResponse['correct']}"
                         reason = f"Reason: {parsedResponse['reason']}\n"
@@ -265,6 +270,7 @@ class QuestionData:
         except Exception as e:
             logging.warn(f"Failed to save question data to file: {questionSavePath}")
             logging.warn(f"Error: {e}")
+
 
 # Using a manual overwrite option for debugging.
 def retrieveQuestions(config, topicModeller=None, videoData=None, overwrite=False):
@@ -404,7 +410,7 @@ def getClusteredTopics(topicModeller, videoData=None):
 
     # This is to handle duplicate topics that share the same name, but have different subtopics.
     cleanTopicList = modifyDuplicateTopics(topicList)
-    
+
     clusteredTopics["Topic Title"] = clusteredTopics["Topic"].apply(
         lambda topic: cleanTopicList[topic]
     )
@@ -503,6 +509,37 @@ There should be four possible answers, with one being the correct answers. Also 
 Return the data in the following JSON format as an example: {{"question": "What is the capital of France?", "answers": ["Paris", "London", "Berlin", "Madrid"], "correct": "Paris", "reason": "Paris is the capital of France"}}"""
 
     return questionTask
+
+
+def truncateRelevantText(dominantTopics, videoData, contextWindowSize=600):
+    for topic in dominantTopics:
+        relevantTextDuration = (
+            dominantTopics[topic]["End"] - dominantTopics[topic]["Start"]
+        )
+
+        if contextWindowSize != 0 and relevantTextDuration > pd.Timedelta(
+            seconds=contextWindowSize
+        ):
+            logging.info(
+                f"Relevant text for Topic: {topic} is longer than context window size of {contextWindowSize} seconds. Truncating..."
+            )
+
+            # Find start of relevant truncated text
+            truncatedSentences = videoData.combinedTranscript[
+                (
+                    videoData.combinedTranscript["End"]
+                    >= (
+                        dominantTopics[topic]["End"]
+                        - pd.Timedelta(seconds=contextWindowSize)
+                    )
+                )
+            ]
+
+            # Store the original start time of the topic
+            dominantTopics[topic]["Original Start"] = dominantTopics[topic]["Start"]
+            dominantTopics[topic]["Start"] = truncatedSentences["Start"].min()
+
+    return dominantTopics
 
 
 def getTextAndQuestion(dominantTopics, videoData):

--- a/questionGenerator.py
+++ b/questionGenerator.py
@@ -512,6 +512,17 @@ Return the data in the following JSON format as an example: {{"question": "What 
 
 
 def truncateRelevantText(dominantTopics, videoData, contextWindowSize=600):
+    """
+    Truncates the relevant text for each dominant topic based on the context window size.
+
+    Args:
+        dominantTopics (dict): A dictionary containing information about the dominant topics.
+        videoData (DataFrame): A DataFrame containing the combined transcript of the video.
+        contextWindowSize (int, optional): The size of the context window in seconds. Defaults to 600.
+
+    Returns:
+        dict: The updated dominantTopics dictionary with truncated relevant text.
+    """
     for topic in dominantTopics:
         relevantTextDuration = (
             dominantTopics[topic]["End"] - dominantTopics[topic]["Start"]


### PR DESCRIPTION
This should also be a small PR to fix #27.

A `.env` variable has been added called `RELEVANT_TEXT_CONTEXT_WINDOW`.
This is optional and can be turned off entirely, but what it does is it will truncate the amount of relevant text being used for generating questions for a given topic. 

The reason for having this option is that sometimes a singular topic might be talked about for a long amount of time, sometimes stretching into 30+ minutes even. In these cases, a lot of text is added to the prompt, with the exact source of the question from the text spread over a long time period. By using a context window, we can only use the tail end of the relevant text from which we generate a question. This reduces the size of the API call and also ensures a question is generated from the transcript that is more recent to what the viewer was watching. 

This might not be immediately useful, but gives us an extra option to leverage when tuning the pipeline based on feedback.
