### PR TITLE
Fix for #25

### DIFF
--- a/captionsProcessor.ipynb
+++ b/captionsProcessor.ipynb
@@ -21,7 +21,7 @@
     "# ]\n",
     "\n",
     "config = configVars()\n",
-    "config.videoToUse = \"New Google Assignments in Canvas\"\n",
+    "config.videoToUse = \"Sakai\"\n",
     "config.setFromEnv()"
    ]
   },

--- a/questionGenerator.py
+++ b/questionGenerator.py
@@ -231,6 +231,17 @@ class QuestionData:
 
                     f.write("\n---------------------------------------\n")
                     f.write(f"Topic: {topic}\n")
+
+                    # Retrieve the keywords for the topic.
+                    keywords = self.clusteredTopics[
+                        (self.clusteredTopics["Topic Title"] == topic)
+                        & (
+                            self.clusteredTopics["End"]
+                            == self.dominantTopics[topic]["End"]
+                        )
+                    ].squeeze()["Words"]
+                    f.write(f"Keywords: {keywords}\n\n")
+                    
                     f.write(
                         f"Transcipt Segment: {startTime.strftime('%H:%M:%S')}"
                         + f" - {endTime.strftime('%H:%M:%S')}\n"


### PR DESCRIPTION
This is a minor addition to the saved file for the human-generated list of questions.
The Keywords that were identified in the given relevant text are listed, to give an indication of how the given topic was clustered. 

It should be important to understand that the keywords are not directly indicative of what the transcript text contains, but rather a heuristic of what was identified within the text, which is still useful to determine whether the topic itself is relevant. 

 Providing a visualization of the topics has not been implemented as it currently does not provide any actionable information from how the topics are spread out over a video. I'm looking into ways to improve upon this, but will refrain from providing a visualization that isn't helpful in my opinion.