### PR TITLE
Fixes for Issue 43 and 45

### DIFF
--- a/Overall Summary ReadMe.md
+++ b/Overall Summary ReadMe.md
@@ -1,0 +1,27 @@
+# Overall Summary of QuestionBot Project
+
+## Brief Description of Project
+
+This ReadMe files aims to be a common reference document to all other links and sources that are linked to the annoto-gai (QuestionBot) project, a Summer '24 Intern project built at U-M ITS Teaching and Learning.
+
+The overall goal of this project was to generate questions that can be inserted into a video to test viewer understanding of the video's content as they watch it. This is done by taking the .srt transcript file from a video, and using the script (usage explained in a separate ReadMe) to generate Question data. A tool called Annoto could be implemented in the future to grab this data and insert the questions into a video.
+
+## Links to other documents and resources:
+
+Detailed steps and instructions can be found in the other ReadMe files within this project.
+
+For the ReadMe for running the code, go to [README.md](https://github.com/tl-its-umich-edu/annoto-gai/blob/main/README.md)
+
+For the ReadMe for evalutating the generated questions via the Excel file, go to [Question Analysis ReadMe.md]()
+
+Refer [Issue #44](https://github.com/tl-its-umich-edu/annoto-gai/issues/44) for current limitation of QuestionBot as of 7/23/24.
+
+ Note that files hosted on Google Drive are restricted to only members of the ITS T&L group.
+
+Misc. Documentation associated with the project can be found on [Google Drive](https://drive.google.com/drive/folders/1NWzh-ejcXPck7j3cAl9RP4X_ZEiDqrWF?usp=sharing).
+
+A large sample of generated question data based of various U-M MiVideo videos from workshops and some classes can be accessed on [Google Drive](https://drive.google.com/drive/folders/1v47l4cGIVsmBYtL5zPlExkppRhySDrQN?usp=drive_link).
+
+[Google Drive link](https://drive.google.com/file/d/131VgUmWHP_PSLCjCU3Ytb44qU9FezltI/view?usp=drive_link) to the Poster made for this project.
+
+[Google Drive link](https://drive.google.com/file/d/1AYRYB42kuHVV6ms2HcPYRNaWTrhGA6Qw/view?usp=drive_link) to the Presentation made for this project.

--- a/Overall Summary ReadMe.md
+++ b/Overall Summary ReadMe.md
@@ -10,18 +10,14 @@ The overall goal of this project was to generate questions that can be inserted 
 
 Detailed steps and instructions can be found in the other ReadMe files within this project.
 
-For the ReadMe for running the code, go to [README.md](https://github.com/tl-its-umich-edu/annoto-gai/blob/main/README.md)
+For the ReadMe for running the code, go to [README.md](https://github.com/tl-its-umich-edu/annoto-gai/blob/main/README.md)  
+For the ReadMe to evaluate the generated questions via the Excel file, go to [Question Analysis ReadMe.md](https://github.com/tl-its-umich-edu/annoto-gai/blob/main/Question%20Analysis%20ReadMe.md)  
 
-For the ReadMe for evalutating the generated questions via the Excel file, go to [Question Analysis ReadMe.md]()
+Refer [Issue #44](https://github.com/tl-its-umich-edu/annoto-gai/issues/44) for current limitations of QuestionBot as of 7/23/24.
 
-Refer [Issue #44](https://github.com/tl-its-umich-edu/annoto-gai/issues/44) for current limitation of QuestionBot as of 7/23/24.
+> Note that files hosted on Google Drive are restricted to only members of the ITS T&L group.
 
- Note that files hosted on Google Drive are restricted to only members of the ITS T&L group.
-
-Misc. Documentation associated with the project can be found on [Google Drive](https://drive.google.com/drive/folders/1NWzh-ejcXPck7j3cAl9RP4X_ZEiDqrWF?usp=sharing).
-
-A large sample of generated question data based of various U-M MiVideo videos from workshops and some classes can be accessed on [Google Drive](https://drive.google.com/drive/folders/1v47l4cGIVsmBYtL5zPlExkppRhySDrQN?usp=drive_link).
-
-[Google Drive link](https://drive.google.com/file/d/131VgUmWHP_PSLCjCU3Ytb44qU9FezltI/view?usp=drive_link) to the Poster made for this project.
-
-[Google Drive link](https://drive.google.com/file/d/1AYRYB42kuHVV6ms2HcPYRNaWTrhGA6Qw/view?usp=drive_link) to the Presentation made for this project.
+Misc. Documentation associated with the project can be found on [Google Drive](https://drive.google.com/drive/folders/1NWzh-ejcXPck7j3cAl9RP4X_ZEiDqrWF?usp=sharing).  
+A large sample of generated question data based of various U-M MiVideo videos from workshops and some classes can be accessed on [Google Drive](https://drive.google.com/drive/folders/1v47l4cGIVsmBYtL5zPlExkppRhySDrQN?usp=drive_link).  
+[Google Drive link](https://drive.google.com/file/d/131VgUmWHP_PSLCjCU3Ytb44qU9FezltI/view?usp=drive_link) to the Poster made for this project.  
+[Google Drive link](https://drive.google.com/file/d/1AYRYB42kuHVV6ms2HcPYRNaWTrhGA6Qw/view?usp=drive_link) to the Presentation made for this project. 

--- a/Question Analysis ReadMe.md
+++ b/Question Analysis ReadMe.md
@@ -1,0 +1,28 @@
+# Instructions for Analysis and Evaluation of Questions
+
+This ReadMe outlines the steps needed to evaluate the generated Questions for a given transcript. 
+The Excel file that follows the naming format `Question Analysis - ****.xlsx` will be the main file used. 
+
+For every transcript, two generation models: `LangChain` and `BERTopic` are used to generate 4 questions each, for a total of 8 questions per transcript. 
+Each Question can be evaluated across three categories:
+1. Relevance - Is this question relevant to the topics covered in the transcript? 
+2. Quality - Is this question of suitable quality? This is a more subjective determination of whether the question makes sense, and if the answers and reasoning are suffiecient.
+3. Usefulness - Is this question useful in context of ensuring a viewer is paying attention to the video, and has understood the material presented?
+
+A suitable evaluation schema would be for a scale of 1 to 5 to be used, where 1 is the lowest score, and a 5 is the highest score for any given question. There are 3 columns corresponding to each question in the Excel file where a score for each question can be typed in.
+
+Each subfolder consists of 4 files: 
+1. The Transcript .srt file used,
+2. 2 .txt files for each of the questions generated from each generation model,
+3. An Excel file to be used for evaluating the generated Questions.
+
+The Excel file consists of most information that would be useful in evaluating each question including: 
+1. Model
+2. Question
+3. Start & End Times
+4. Possible Answers
+5. Reasoning
+6. 3 Evaluation questions
+7. Transcript text used for generating the question
+
+### TL,DR: Use the Excel file to rate each Question (4 questions each for 2 generation models) generated from 1 to 5 across 3 Evalutation Criteria.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# annoto-gai
+# QuestionBot (Also known as annoto-gai)
 This is the Github Project to Annoto GAI work.
 
 ## Initial setup: 

--- a/captionsProcessor.ipynb
+++ b/captionsProcessor.ipynb
@@ -24,10 +24,16 @@
    "outputs": [],
    "source": [
     "from transcriptLoader import retrieveTranscript\n",
+    "from topicExtractor import retrieveTopics\n",
     "from questionGenerator import retrieveQuestions\n",
     "\n",
     "videoData = retrieveTranscript(config)\n",
-    "questionData = retrieveQuestions(config, videoData=videoData)"
+    "topicModeller = None\n",
+    "if config.generationModel == \"BERTopic\":\n",
+    "    print(f\"\\t--> Retrieving Topics for {config.videoToUse}...\")\n",
+    "    topicModeller = retrieveTopics(config, videoData)\n",
+    "\n",
+    "generatedData = retrieveQuestions(config, videoData=videoData, topicModeller=topicModeller)"
    ]
   },
   {
@@ -81,16 +87,7 @@
     "# This list is a list of videos present in the Captions folder for which the questions are to be generated.\n",
     "# To generate questions for all videos in the Captions folder, set fileList = os.listdir(captionsFolder)\n",
     "fileList = [\n",
-    "    \"IMSE 514 Presentation\",\n",
-    "    \"Kalpana-GenAI-Das\",\n",
-    "    \"Kalpana-maizey2-das\",\n",
-    "    \"Kalpana-U-M MaizeyDas\",\n",
-    "    \"New Google Assignments in Canvas\",\n",
-    "    \"New Quizzes - Basics\",\n",
-    "    \"New Quizzes Video\",\n",
-    "    \"Piazza Introduction Workshop\",\n",
-    "    # \"Rearrange Playlist video\",\n",
-    "    \"Sakai\",\n",
+    "    # Insert the names of the videos for which questions are to be generated.\n",
     "]\n",
     "\n",
     "# This is hardcoded, based on the known column it would be assigned to in the Excel file.\n",

--- a/topicExtractor.py
+++ b/topicExtractor.py
@@ -150,16 +150,17 @@ class TopicModeller:
                 logging.info(f"Topics and probalities extracted from fitted successfully.")
 
                 if set(self.topics) == {-1}:
-                    logging.warning(
+                    logging.warn(
                         "All topics are -1. Retrying with K-means clustering..."
                     )
                     KMeansAttempt = self.useKMeans(vectorizerModel, docs)
 
+                    KMeansAttemptWithoutVectorizer = True
                     if not KMeansAttempt:
                         logging.warn("Retrying without Vectorizer model.")
-                        KMeansAttempt = self.useKMeans(None, docs)
+                        KMeansAttemptWithoutVectorizer = self.useKMeans(None, docs)
 
-                    if not KMeansAttempt:
+                    if not KMeansAttemptWithoutVectorizer:
                         logging.error("Failed to fit the topic model with K-means clustering. This is unexpected behavior. Exiting...")
                         return False
 
@@ -223,7 +224,8 @@ class TopicModeller:
             self.initializeTopicModel(vectorizerModel, clusterModel)
             self.topics, probs = self.topicModel.fit_transform(docs)
             return True
-        except:
+        except Exception as e:
+            logging.error(f"Error Message: {e}")
             logging.warn("Failed to fit the topic model with K-means clustering.")
             return False
 

--- a/topicExtractor.py
+++ b/topicExtractor.py
@@ -116,8 +116,9 @@ class TopicModeller:
 
         Args:
             vectorizerModel (object, optional): Vectorizer model for the topic model. Defaults to None.
+            clusterModel (object, optional): Cluster model for the topic model. Defaults to None.
         """
-        if vectorizerModel is not None:
+        if vectorizerModel is not None and clusterModel is None:
             self.topicModel = BERTopic(
                 representation_model=self.representationModel,
                 vectorizer_model=vectorizerModel,
@@ -156,7 +157,7 @@ class TopicModeller:
 
                     if not KMeansAttempt:
                         logging.warn("Retrying without Vectorizer model.")
-                        self.useKMeans(None, docs)
+                        KMeansAttempt = self.useKMeans(None, docs)
 
                     if not KMeansAttempt:
                         logging.error("Failed to fit the topic model with K-means clustering. This is unexpected behavior. Exiting...")

--- a/topicExtractor.py
+++ b/topicExtractor.py
@@ -225,8 +225,7 @@ class TopicModeller:
             self.topics, probs = self.topicModel.fit_transform(docs)
             return True
         except Exception as e:
-            logging.error(f"Error Message: {e}")
-            logging.warn("Failed to fit the topic model with K-means clustering.")
+            logging.warn(f"Failed to fit the topic model with K-means clustering due to {e}")
             return False
 
     def getTopicsOverTime(self):


### PR DESCRIPTION
Fix for #43
Fix for #45 

 #43 was raised to address an error that occurs very rarely (I could only make it happen once) on some videos where there is absolutely no clear topic consensus on any level where even KMeans clustering fails. I adjusted the code to account for this possibility with one more check and to ensure the script exits cleanly if something does not work. No other functionality has been changed, and this does not affect the generated data from past runs. 

To address #45, I added the ReadMe files used for evaluating the Excel files for the question data, as well as the Overall Summary ReadMe file that contains a brief description of the project and various links to other resources tied to this project. All of the Google Drive links are restricted to T&L as the data is hosted on a T&L Drive. This should allow for the repo to host all documentation and links in one place for easier reference in the future.